### PR TITLE
Mmap

### DIFF
--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -38,6 +38,7 @@ library
     , directory
     , either
     , filepath
+    , mmap
     , mtl
     , tagged
     , temporary

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -94,8 +94,7 @@ packIndexDataStart v = packIndexHeaderSize v + 256 * 4
 
 getPackIndexVersion
   :: MonadError GitError m => MmapHandle -> m Version
-getPackIndexVersion h = let magic = mmapData h (FromStart 0) (Length 4) in do
-  case magic of
+getPackIndexVersion h = case mmapData h (FromStart 0) (Length 4) of
     "\255tOc" -> let version = mmapWord32be h (FromStart 4) in
       if version == 2
         then return Version2

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -81,10 +81,10 @@ instance Show PackIndexState where
 
 withPackIndex
   :: MonadIO m
-  => FilePath -> IOMode -> StateT PackIndexState (ExceptT GitError m) r
+  => FilePath -> StateT PackIndexState (ExceptT GitError m) r
   -> m (Either GitError r)
-withPackIndex path mode m = runExceptT $ do
-  h <- excTIO $ openBinaryFile path mode
+withPackIndex path m = runExceptT $ do
+  h <- excTIO $ openBinaryFile path ReadMode
   v <- getPackIndexVersion h
   res <- evalStateT m (packIndexState v h)
   -- FIXME: this might be better bracketed in case of error, although the RTS

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -213,6 +213,8 @@ getPackIndexRecordNo sha1 = do
           put $ pis {pisRecordNos = Map.insert sha1 recordNo $ pisRecordNos pis}
           return recordNo
   where
+    -- FIXME: this could be faster if implemented as a binary search, since the
+    -- entries are ordered:
     findSha1Idx
       :: MonadError GitError m => Word32 -> Word32 -> LBS.ByteString -> m Word32
     findSha1Idx totRecs i lbs = let (first, rest) = LBS.splitAt 20 lbs in do

--- a/src/Git/Pack/Pack.hs
+++ b/src/Git/Pack/Pack.hs
@@ -34,9 +34,9 @@ data PackHandle = PackHandle
   , phNumObjects :: Word32
   } deriving (Show)
 
-openPackFile :: (MonadIO m, MonadFail m) => FilePath -> IOMode -> m PackHandle
-openPackFile path mode = do
-    h <- liftIO $ openBinaryFile path mode
+openPackFile :: (MonadIO m, MonadFail m) => FilePath -> m PackHandle
+openPackFile path = do
+    h <- liftIO $ openBinaryFile path ReadMode
     (version, numObjects) <- (liftIO $ BS.hGet h 12) >>=
       either fail return . parseOnly headerP
     unless (version == 2) $ fail "openPackFile: unsupported version"

--- a/src/Git/Pack/Pack.hs
+++ b/src/Git/Pack/Pack.hs
@@ -77,7 +77,7 @@ getPackObjectInfo ph offset = either fail return $ parseOnly objHeadP $
       ty <- decodePackObjectType $ shift (byte1 .&. 0b01110000) (-4)
       let lenHead = fromIntegral $ byte1 .&. 0b00001111
       if msb == 0
-        then return (ty, offset + 4,lenHead)
+        then return (ty, offset + 4, lenHead)
         else do
           (o, l) <- lengthChunkP lenHead 4
           return $ (ty, offset + fromIntegral o, l)

--- a/src/Git/Pack/Pack.hs
+++ b/src/Git/Pack/Pack.hs
@@ -8,18 +8,17 @@ import Codec.Compression.Zlib (decompress)
 import Control.Monad (unless)
 import Control.Monad.Fail (MonadFail(..))
 import Control.Monad.IO.Class (MonadIO(..))
-import Data.Attoparsec.ByteString
-  (parseOnly, parseWith, eitherResult, string, (<?>), anyWord8)
+import Data.Attoparsec.ByteString (Parser, parseOnly, string, (<?>), anyWord8)
 import Data.Attoparsec.Binary (anyWord32be)
 import Data.Bits ((.&.), (.|.), shift)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Word
-import System.IO
-  (Handle, IOMode(..), openBinaryFile, hSeek, SeekMode(..), hTell)
+import System.IO.MMap (mmapFileForeignPtr, Mode(..))
 
+import Git.Serialise (tellParsePos)
 import Git.Types (Sha1, sha1Size)
-import qualified Git.Types.Sha1 as Sha1
+import Git.Types.Internal
+  (MmapHandle, mmapData, MmapFrom(..), MmapTo(..), mmapSha1)
 import Git.Types.SizedByteString (SizedByteString)
 import qualified Git.Types.SizedByteString as SBS
 
@@ -30,15 +29,15 @@ data PackObjectType
   | PotOfsDelta | PotRefDelta deriving (Show, Eq)
 
 data PackHandle = PackHandle
-  { phHandle :: Handle
+  { phMmap :: MmapHandle
   , phNumObjects :: Word32
   } deriving (Show)
 
 openPackFile :: (MonadIO m, MonadFail m) => FilePath -> m PackHandle
 openPackFile path = do
-    h <- liftIO $ openBinaryFile path ReadMode
-    (version, numObjects) <- (liftIO $ BS.hGet h 12) >>=
-      either fail return . parseOnly headerP
+    h <- liftIO $ mmapFileForeignPtr path ReadOnly Nothing
+    (version, numObjects) <- either fail return $ parseOnly headerP $
+        mmapData h (FromStart 0) (Length 12)
     unless (version == 2) $ fail "openPackFile: unsupported version"
     return $ PackHandle h numObjects
   where
@@ -48,14 +47,11 @@ openPackFile path = do
       numObjects <- anyWord32be
       return (version, numObjects)
 
-getPackSha1FromPack :: (MonadIO m, MonadFail m) => PackHandle -> m Sha1
-getPackSha1FromPack ph = let h = phHandle ph in do
-    liftIO $ hSeek h SeekFromEnd (-fromIntegral sha1Size)
-      >> BS.hGet h (fromIntegral sha1Size)
-      >>= Sha1.fromByteString
+getPackSha1FromPack :: PackHandle -> Sha1
+getPackSha1FromPack ph = mmapSha1 (phMmap ph) $ FromEnd (-sha1Size)
 
-decodePackObjecType :: MonadFail m => Word8 -> m PackObjectType
-decodePackObjecType w = case w of
+decodePackObjectType :: MonadFail m => Word8 -> m PackObjectType
+decodePackObjectType w = case w of
   1 -> return PotCommit
   2 -> return PotTree
   3 -> return PotBlob
@@ -64,42 +60,41 @@ decodePackObjecType w = case w of
   7 -> return PotRefDelta
   _ -> traceShow w $ fail "Unrecognised object type"
 
+-- | Gets the type of packed object, the start offset of the actual data blob
+--   (i.e. the position in the file after we've read the object header) and the
+--   size of the _uncompressed_ data for the blob.
 getPackObjectInfo
-  :: (MonadIO m, MonadFail m) => PackHandle -> Word64
-  -> m (PackObjectType, Integer, Integer)
-getPackObjectInfo ph offset =
-  let
-    h = phHandle ph
-    getByte = liftIO $ BS.hGet h 1
-  in do
-    liftIO $ hSeek h AbsoluteSeek $ fromIntegral offset
-    -- FIXME: don't think reading from the file a byte at a time is the smartest
-    -- move, but perhaps the kernel or RTS does something clever?
-    (ty, size) <- getByte >>= parseWith getByte objHeadP >>=
-         either fail return . eitherResult
-    dataStart <- liftIO $ hTell h
-    return (ty, dataStart, size)
+  :: MonadFail m => PackHandle -> Word64 -> m (PackObjectType, Word64, Word64)
+getPackObjectInfo ph offset = either fail return $ parseOnly objHeadP $
+    -- It's ok to make a long bytestring from the mmapped file, because it won't
+    -- actually be read by the kernel until we need it, and we'll stop parsing
+    -- after the header is done:
+    mmapData (phMmap ph) (FromStart $ fromIntegral offset) ToEnd
   where
     objHeadP = do
       byte1 <- anyWord8
       let msb = byte1 .&. 0b10000000
-      ty <- decodePackObjecType $ shift (byte1 .&. 0b01110000) (-4)
+      ty <- decodePackObjectType $ shift (byte1 .&. 0b01110000) (-4)
       let lenHead = fromIntegral $ byte1 .&. 0b00001111
       if msb == 0
-        then return (ty, lenHead)
-        else lengthChunkP lenHead 4 >>= return . (ty,)
+        then return (ty, offset + 4,lenHead)
+        else do
+          (o, l) <- lengthChunkP lenHead 4
+          return $ (ty, offset + fromIntegral o, l)
+    lengthChunkP :: Word64 -> Int -> Parser (Int, Word64)
     lengthChunkP lenHead i = do
       byte <- anyWord8
       let msb = byte .&. 0b10000000
       let lenHead' = lenHead .|. shift (fromIntegral $ byte .&. 0b01111111) i
+      pos <- tellParsePos
       if msb == 0
-        then return lenHead'
+        then return (pos, lenHead')
         else lengthChunkP lenHead' $ i + 7
 
 -- | Uses LBS.hGetContents, so requires that PackHandle is no longer used for
 --   anything else.
-getObjectDataFromPack
-  :: MonadIO m => PackHandle -> Integer -> Integer -> m SizedByteString
-getObjectDataFromPack ph offset len = let h = phHandle ph in do
-  liftIO $ hSeek h AbsoluteSeek offset
-  SBS.takeFromLazyByteString len . decompress <$> liftIO (LBS.hGetContents h)
+getPackObjectData :: PackHandle -> Word64 -> Word64 -> SizedByteString
+getPackObjectData ph offset len =
+  SBS.takeFromLazyByteString (fromIntegral len) $ decompress $
+  LBS.fromStrict $ mmapData (phMmap ph)
+  (FromStart $ fromIntegral offset) (Length $ fromIntegral len)

--- a/src/Git/Store.hs
+++ b/src/Git/Store.hs
@@ -58,12 +58,12 @@ retrieveObject storePath sha1 = do
         packName <- replaceSuffix "idx" "pack" indexName
         -- FIXME: this currently leaks too many details of how to look at pack
         -- files...
-        ph <- openPackFile (storePath </> "pack" </> packName) ReadMode
+        ph <- openPackFile (storePath </> "pack" </> packName)
         (ty, offset, size) <- getPackObjectInfo ph packOffset
         -- FIXME: this DOES NOT CHECK THE OBJECT TYPE!
         getObjectDataFromPack ph offset size >>=
           lazyParseOnly (objectParser size <* endOfInput) . SBS.toLazyByteString
     searchPackIndex :: (MonadIO m, MonadError String m) => FilePath -> m Word64
     searchPackIndex path =
-      withPackIndex path ReadMode (getPackRecordOffset $ unTagged sha1) >>=
+      withPackIndex path (getPackRecordOffset $ unTagged sha1) >>=
       either (throwError . show) return

--- a/src/Git/Types/Internal.hs
+++ b/src/Git/Types/Internal.hs
@@ -9,7 +9,16 @@ module Git.Types.Internal where
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
 import Control.Monad.Except (ExceptT(..), MonadError, throwError, runExceptT)
+import Data.Attoparsec.ByteString (parseOnly)
+import Data.Attoparsec.Binary (anyWord32be, anyWord64be)
 import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BSIntern
+import Data.Word
+import Foreign.ForeignPtr (ForeignPtr)
+
+import Git.Types.Sha1 (Sha1)
+import qualified Git.Types.Sha1 as Sha1
 
 instance MonadFail (Either String) where
   fail = Left
@@ -45,3 +54,32 @@ dropLengthMaybe :: MonadFail m => [a] -> [b] -> m [b]
 dropLengthMaybe [] bs = return bs
 dropLengthMaybe _ [] = fail "Ran out of bs"
 dropLengthMaybe (_:as) (_:bs) = dropLengthMaybe as bs
+
+type MmapHandle = (ForeignPtr Word8, Int, Int)
+
+data MmapFrom = FromStart Int | FromEnd Int deriving (Show)
+data MmapTo = Length Int | ToEnd deriving (Show)
+
+mmapData :: MmapHandle -> MmapFrom -> MmapTo -> BS.ByteString
+mmapData (ptr, mmapOfs, mmapSize) from to =
+  let
+    startOfs = case from of
+      FromStart i -> mmapOfs + i
+      FromEnd i -> mmapOfs + mmapSize - i
+    len = case to of
+      Length i -> i
+      ToEnd -> mmapOfs + mmapSize - startOfs
+  in
+    BSIntern.fromForeignPtr ptr startOfs len
+
+mmapWord32be :: MmapHandle -> MmapFrom -> Word32
+mmapWord32be h from = either error id $ parseOnly anyWord32be $
+  mmapData h from (Length 4)
+
+mmapWord64be :: MmapHandle -> MmapFrom -> Word64
+mmapWord64be h from = either error id $ parseOnly anyWord64be $
+  mmapData h from (Length 8)
+
+mmapSha1 :: MmapHandle -> MmapFrom -> Sha1
+mmapSha1 h from = either error id $ Sha1.fromByteString $
+  mmapData h from (Length 20)


### PR DESCRIPTION
This changes the IO model of the library to use memory mapped files. I think it should have a number of advantages in the near future - mostly around being able to point objects at blobs of data without having to worry about closed file handles/`hGetContents`/lazy bytestrings.