### PR TITLE
Handle reconstruting objects from deltas when reading a packfile

### DIFF
--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -36,7 +36,6 @@ library
     , containers
     , cryptohash
     , directory
-    , either
     , filepath
     , mmap
     , mtl

--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -52,6 +52,7 @@ library
     , Git.Pack.Delta
     , Git.Pack.Index
     , Git.Pack.Pack
+    , Git.Pack.PackSet
     , Git.Serialise
     , Git.Store
     , Git.Types

--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -55,6 +55,7 @@ library
     , Git.Serialise
     , Git.Store
     , Git.Types
+    , Git.Types.Error
     , Git.Types.Internal
     , Git.Types.Objects
     , Git.Types.Sha1

--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -83,7 +83,9 @@ test-suite hs-git-test
   main-is: Spec.hs
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -XOverloadedStrings
+  ghc-options:
+      -threaded -rtsopts -with-rtsopts=-N -Wall -XScopedTypeVariables
+      -XOverloadedStrings
   build-depends:
       base >=4.7 && <5
     , hs-git-tools
@@ -92,9 +94,11 @@ test-suite hs-git-test
     , knob
     , mtl
     , hspec
+    , QuickCheck
   other-modules:
       Git.SerialiseSpec
       Git.Pack.DeltaSpec
+      Git.Pack.PackSpec
       Git.Types.SizedByteStringSpec
       Paths_hs_git_tools
   default-language: Haskell2010

--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -50,6 +50,7 @@ library
   exposed-modules:
       Git
     , Git.Pack
+    , Git.Pack.Delta
     , Git.Pack.Index
     , Git.Pack.Pack
     , Git.Serialise
@@ -89,9 +90,11 @@ test-suite hs-git-test
     , attoparsec
     , bytestring
     , knob
+    , mtl
     , hspec
   other-modules:
       Git.SerialiseSpec
+      Git.Pack.DeltaSpec
       Git.Types.SizedByteStringSpec
       Paths_hs_git_tools
   default-language: Haskell2010

--- a/src/Git/Pack.hs
+++ b/src/Git/Pack.hs
@@ -2,3 +2,4 @@ module Git.Pack (module X) where
 
 import Git.Pack.Index as X
 import Git.Pack.Pack as X
+import Git.Pack.PackSet as X

--- a/src/Git/Pack/Delta.hs
+++ b/src/Git/Pack/Delta.hs
@@ -15,11 +15,15 @@ data DeltaInstruction
   = Insert {insData :: SizedByteString}
   | Copy {copyOffset :: Word32, copyLength :: Word32}
 
+instance Show DeltaInstruction where
+  show (Insert dat) = printf "<Insert %d>" (SBS.length dat)
+  show (Copy o l) = printf "<Copy %d %d>" o l
+
 data DeltaBody = DeltaBody
   { dbSourceLen :: Word64
   , dbTargetLen :: Word64
   , dbInstructions :: [DeltaInstruction]
-  }
+  } deriving Show
 
 data PackObjectChain
   = PackObjectChain

--- a/src/Git/Pack/Delta.hs
+++ b/src/Git/Pack/Delta.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Git.Pack.Delta where
+
+import Control.Monad (unless)
+import Control.Monad.Except (MonadError(..))
+import Data.Word
+import Text.Printf (printf)
+
+import Git.Types (ObjectType, GitError(..))
+import Git.Types.SizedByteString (SizedByteString)
+import qualified Git.Types.SizedByteString as SBS
+
+data DeltaInstruction
+  = Insert {insData :: SizedByteString}
+  | Copy {copyOffset :: Word32, copyLength :: Word32}
+
+data DeltaBody = DeltaBody
+  { dbSourceLen :: Word64
+  , dbTargetLen :: Word64
+  , dbInstructions :: [DeltaInstruction]
+  }
+
+data PackObjectChain
+  = PackObjectChain
+  { pocTy :: ObjectType
+  , pocBaseData :: SizedByteString
+  , pocDeltas :: [DeltaBody]}
+
+instance Show PackObjectChain where
+  show poc = printf "<PackObjectChain: %s %d>" (show $ pocTy poc)
+    (length $ pocDeltas poc)
+
+pocConsDelta :: DeltaBody -> PackObjectChain -> PackObjectChain
+pocConsDelta d poc = poc { pocDeltas = d : pocDeltas poc}
+
+renderPackObjectChain
+  :: MonadError GitError m
+  => PackObjectChain -> m (ObjectType, SizedByteString)
+renderPackObjectChain (PackObjectChain ty baseData deltas) =
+    (ty,) <$> go deltas baseData
+  where
+    go [] b = return b
+    go (d:ds) b = applyDelta b d >>= go ds
+
+applyDelta
+  :: MonadError GitError m
+  => SizedByteString -> DeltaBody -> m SizedByteString
+applyDelta base (DeltaBody srcLen targLen inss) = do
+  unless (SBS.length base == srcLen) $
+    throwError $ FailedPreDeltaApplicationLengthCheck (SBS.length base) srcLen
+  let new = mconcat $ fmap (applyInstruction base) inss
+  unless (SBS.length new == targLen) $
+    throwError $ FailedPostDeltaApplicationLengthCheck (SBS.length new) targLen
+  return new
+
+applyInstruction :: SizedByteString -> DeltaInstruction -> SizedByteString
+applyInstruction base i = case i of
+  Insert sbs -> sbs
+  Copy ofs len -> SBS.take (fromIntegral len) $ SBS.drop (fromIntegral ofs) base

--- a/src/Git/Pack/Delta.hs
+++ b/src/Git/Pack/Delta.hs
@@ -44,8 +44,8 @@ deltaBodyOk :: DeltaBody -> Bool
 deltaBodyOk db =
   sum (fmap deltaInsResultLen $ dbInstructions db) == dbTargetLen db
 
-pocConsDelta :: DeltaBody -> PackObjectChain -> PackObjectChain
-pocConsDelta d poc = poc { pocDeltas = d : pocDeltas poc}
+pocAppendDelta :: DeltaBody -> PackObjectChain -> PackObjectChain
+pocAppendDelta d poc = poc { pocDeltas = pocDeltas poc ++ [d]}
 
 renderPackObjectChain
   :: MonadError GitError m

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -94,8 +94,7 @@ packIndexDataStart v = packIndexHeaderSize v + 256 * 4
 
 getPackIndexVersion
   :: MonadError GitError m => MmapHandle -> m Version
-getPackIndexVersion h = let magic = mmapData h (FromStart 0) (Length 4) in do
-  case magic of
+getPackIndexVersion h = case mmapData h (FromStart 0) (Length 4) of
     "\255tOc" -> let version = mmapWord32be h (FromStart 4) in
       if version == 2
         then return Version2

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -20,24 +20,10 @@ import Text.Printf (printf)
 import Git.Types.Internal
   ( MmapHandle, MmapFrom(..), MmapTo(..), mmapData
   , mmapWord32be, mmapWord64be, mmapSha1)
-import Git.Types (Sha1(..), sha1Size)
+import Git.Types (Sha1(..), sha1Size, GitError(..))
 
 data Version = Version1 | Version2 deriving (Show, Eq, Enum, Bounded)
 
-data GitError
-  = ErrorWithIO IOError
-  | ParseError String
-  | UnsupportedPackIndexVersion
-  | UnsupportedOperation String
-  | Sha1NotInIndex
-
-instance Show GitError where
-  show e = case e of
-    ErrorWithIO ioe -> "IO error: " ++ show ioe
-    ParseError s -> "Parse error: " ++ s
-    UnsupportedPackIndexVersion -> "Unsupported pack index version"
-    UnsupportedOperation s -> "Unsupported operation: " ++ s
-    Sha1NotInIndex -> "sha1 not in index"
 
 data PackIndexState
   = PackIndexStateV1

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -141,7 +141,7 @@ getPackIndexRecordNo sha1 = do
       Version1 -> throwError UnsupportedPackIndexVersion
       Version2 -> do
           let (minRecordNo, maxRecordNo) = getPackIndexRecordNoBounds pis sha1
-          recordNo <- findSha1Idx maxRecordNo minRecordNo $ getSha1 $ pisMmap pis
+          recordNo <- findSha1Idx minRecordNo maxRecordNo $ getSha1 $ pisMmap pis
           put $ pis {pisRecordNos = Map.insert sha1 recordNo $ pisRecordNos pis}
           return recordNo
   where

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -24,7 +24,6 @@ import Git.Types (Sha1(..), sha1Size, GitError(..))
 
 data Version = Version1 | Version2 deriving (Show, Eq, Enum, Bounded)
 
-
 data PackIndexState
   = PackIndexStateV1
     { pisMmap :: MmapHandle
@@ -60,6 +59,13 @@ instance Show PackIndexState where
       totRecs = runIdentity $ evalStateT getPackIndexTotalRecords pis
     in
       printf "<PackIndexState: %s, records: %d>" (show v) totRecs
+
+openPackIndex
+  :: (MonadIO m, MonadError GitError m) => FilePath -> m PackIndexState
+openPackIndex indexPath = do
+  h <- liftIO $ mmapFileForeignPtr indexPath ReadOnly Nothing
+  v <- getPackIndexVersion h
+  return $ packIndexState v h
 
 withPackIndex
   :: MonadIO m

--- a/src/Git/Pack/Index.hs
+++ b/src/Git/Pack/Index.hs
@@ -151,11 +151,11 @@ getPackIndexRecordNo sha1 = do
       :: MonadError GitError m
       => Word32 -> Word32 -> (Word32 -> Sha1) -> m Word32
     findSha1Idx minRn maxRn fetch = let candidate = (minRn + maxRn) `div` 2 in
-      if minRn == maxRn then throwError Sha1NotInIndex else
+      if minRn > maxRn then throwError Sha1NotInIndex else
       case compare (fetch candidate) sha1 of
-        LT -> findSha1Idx candidate maxRn fetch
+        LT -> findSha1Idx (candidate + 1) maxRn fetch
         EQ -> return candidate
-        GT -> findSha1Idx minRn candidate fetch
+        GT -> findSha1Idx minRn (candidate - 1) fetch
 
 getPackRecordCrc
   :: (MonadState PackIndexState m, MonadError GitError m)

--- a/src/Git/Pack/Pack.hs
+++ b/src/Git/Pack/Pack.hs
@@ -77,7 +77,7 @@ getPackObjectInfo ph offset = either fail return $ parseOnly objHeadP $
       ty <- decodePackObjectType $ shift (byte1 .&. 0b01110000) (-4)
       let lenHead = fromIntegral $ byte1 .&. 0b00001111
       if msb == 0
-        then return (ty, offset + 4,lenHead)
+        then return (ty, offset + 4, lenHead)
         else do
           (o, l) <- lengthChunkP lenHead 4
           return $ (ty, offset + fromIntegral o, l)

--- a/src/Git/Pack/Pack.hs
+++ b/src/Git/Pack/Pack.hs
@@ -1,44 +1,74 @@
-{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE
+    BinaryLiterals
+  , FlexibleContexts
+#-}
 
 module Git.Pack.Pack where
 
-import Prelude hiding (fail)
+import Prelude hiding (fail, take)
 
 import Codec.Compression.Zlib (decompress)
 import Control.Monad (unless)
+import Control.Monad.Except (MonadError(..))
 import Control.Monad.Fail (MonadFail(..))
 import Control.Monad.IO.Class (MonadIO(..))
-import Data.Attoparsec.ByteString (Parser, parseOnly, string, (<?>), anyWord8)
+import Data.Attoparsec.ByteString
+  ( Parser, parseOnly, string, (<?>), anyWord8, take, many1, peekWord8'
+  , takeLazyByteString)
 import Data.Attoparsec.Binary (anyWord32be)
-import Data.Bits ((.&.), (.|.), shift)
+import Data.Bits (Bits, (.&.), (.|.), shift, shiftL, testBit)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List as List
 import Data.Word
 import System.IO.MMap (mmapFileForeignPtr, Mode(..))
+import Text.Printf (printf)
 
 import Git.Serialise (tellParsePos)
-import Git.Types (Sha1, sha1Size)
+import Git.Types (Sha1, sha1Size, GitError(..), ObjectType(..))
 import Git.Types.Internal
   (MmapHandle, mmapData, MmapFrom(..), MmapTo(..), mmapSha1)
+import qualified Git.Types.Sha1 as Sha1
 import Git.Types.SizedByteString (SizedByteString)
 import qualified Git.Types.SizedByteString as SBS
+
+import Git.Pack.Delta (DeltaInstruction(..), DeltaBody(..))
 
 import Debug.Trace
 
 data PackObjectType
-  = PotCommit | PotTree | PotBlob | PotTag
-  | PotOfsDelta | PotRefDelta deriving (Show, Eq)
+  = PoTyCommit | PoTyTree | PoTyBlob | PoTyTag
+  | PoTyOfsDelta | PoTyRefDelta deriving (Show, Eq)
+
+packObjTyToObjTy :: MonadError GitError m => PackObjectType -> m ObjectType
+packObjTyToObjTy poc = case poc of
+  PoTyCommit -> return $ ObjTyCommit
+  PoTyTree -> return $ ObjTyTree
+  PoTyBlob -> return $ ObjTyBlob
+  PoTyTag -> return $ ObjTyTag
+  _ -> throwError $ GenericError "Bad pack object type"
+
+data RefDelta = RefDelta {rdBaseSha1 :: Sha1, rdBody :: DeltaBody}
+instance Show RefDelta where
+  show (RefDelta sha1 _) = printf "<RefDelta: %s>" (show sha1)
+
+data OfsDelta = OfsDelta {odBaseNegOfs :: Word64, odBody :: DeltaBody}
+instance Show OfsDelta where
+  show (OfsDelta negOfs _) = printf "<OfsDelta: %d" negOfs
+
+data DeltaObject = RefDelta' RefDelta | OfsDelta' OfsDelta deriving (Show)
 
 data PackHandle = PackHandle
   { phMmap :: MmapHandle
   , phNumObjects :: Word32
   } deriving (Show)
 
-openPackFile :: (MonadIO m, MonadFail m) => FilePath -> m PackHandle
+openPackFile :: (MonadIO m, MonadError GitError m) => FilePath -> m PackHandle
 openPackFile path = do
     h <- liftIO $ mmapFileForeignPtr path ReadOnly Nothing
-    (version, numObjects) <- either fail return $ parseOnly headerP $
-        mmapData h (FromStart 0) (Length 12)
-    unless (version == 2) $ fail "openPackFile: unsupported version"
+    (version, numObjects) <- either (throwError . ParseError) return $
+        parseOnly headerP $ mmapData h (FromStart 0) (Length 12)
+    unless (version == 2) $ throwError UnsupportedPackFileVersion
     return $ PackHandle h numObjects
   where
     headerP = do
@@ -52,49 +82,132 @@ getPackSha1FromPack ph = mmapSha1 (phMmap ph) $ FromEnd (-sha1Size)
 
 decodePackObjectType :: MonadFail m => Word8 -> m PackObjectType
 decodePackObjectType w = case w of
-  1 -> return PotCommit
-  2 -> return PotTree
-  3 -> return PotBlob
-  4 -> return PotTag
-  6 -> return PotOfsDelta
-  7 -> return PotRefDelta
-  _ -> traceShow w $ fail "Unrecognised object type"
+  1 -> return PoTyCommit
+  2 -> return PoTyTree
+  3 -> return PoTyBlob
+  4 -> return PoTyTag
+  6 -> return PoTyOfsDelta
+  7 -> return PoTyRefDelta
+  _ -> fail $ "Unrecognised object type " ++ show w
+
+msb :: Word8 -> Bool
+msb byte = byte .&. 0b10000000 /= 0
+
+lsbs :: Word8 -> Word8
+lsbs = (.&. 0b01111111)
+
 
 -- | Gets the type of packed object, the start offset of the actual data blob
 --   (i.e. the position in the file after we've read the object header) and the
 --   size of the _uncompressed_ data for the blob.
 getPackObjectInfo
-  :: MonadFail m => PackHandle -> Word64 -> m (PackObjectType, Word64, Word64)
-getPackObjectInfo ph offset = either fail return $ parseOnly objHeadP $
-    -- It's ok to make a long bytestring from the mmapped file, because it won't
-    -- actually be read by the kernel until we need it, and we'll stop parsing
-    -- after the header is done:
-    mmapData (phMmap ph) (FromStart $ fromIntegral offset) ToEnd
-  where
-    objHeadP = do
-      byte1 <- anyWord8
-      let msb = byte1 .&. 0b10000000
-      ty <- decodePackObjectType $ shift (byte1 .&. 0b01110000) (-4)
-      let lenHead = fromIntegral $ byte1 .&. 0b00001111
-      if msb == 0
-        then return (ty, offset + 4, lenHead)
-        else do
-          (o, l) <- lengthChunkP lenHead 4
-          return $ (ty, offset + fromIntegral o, l)
-    lengthChunkP :: Word64 -> Int -> Parser (Int, Word64)
-    lengthChunkP lenHead i = do
-      byte <- anyWord8
-      let msb = byte .&. 0b10000000
-      let lenHead' = lenHead .|. shift (fromIntegral $ byte .&. 0b01111111) i
-      pos <- tellParsePos
-      if msb == 0
-        then return (pos, lenHead')
-        else lengthChunkP lenHead' $ i + 7
+  :: MonadError GitError m
+  => PackHandle -> Word64 -> m (PackObjectType, Word64, Word64)
+getPackObjectInfo ph offset = do
+  (objTy, bytesConsumed, objSize) <-
+    either (throwError . ParseError) return $
+        parseOnly objHeadP $
+        -- It's ok to make a long bytestring from the mmapped file, because it
+        -- won't actually be read by the kernel until we need it, and we'll stop
+        -- parsing after the header is done:
+        mmapData (phMmap ph) (FromStart $ fromIntegral offset) ToEnd
+  return (objTy, bytesConsumed + offset, objSize)
 
--- | Uses LBS.hGetContents, so requires that PackHandle is no longer used for
---   anything else.
-getPackObjectData :: PackHandle -> Word64 -> Word64 -> SizedByteString
-getPackObjectData ph offset len =
-  SBS.takeFromLazyByteString (fromIntegral len) $ decompress $
-  LBS.fromStrict $ mmapData (phMmap ph)
-  (FromStart $ fromIntegral offset) (Length $ fromIntegral len)
+objHeadP :: Parser (PackObjectType, Word64, Word64)
+objHeadP = do
+  byte1 <- anyWord8
+  ty <- decodePackObjectType $ shift (byte1 .&. 0b01110000) (-4)
+  let lenHead = fromIntegral $ byte1 .&. 0b00001111
+  len <- if msb byte1
+    then lengthP lenHead
+    else return lenHead
+  pos <- tellParsePos
+  return (ty, fromIntegral pos, len)
+
+lengthP :: Word64 -> Parser Word64
+lengthP lenHead = do
+  byte <- anyWord8
+  let lenHead' = shift lenHead 7 .|. (fromIntegral $ lsbs byte)
+  if msb byte
+    then lengthP lenHead'
+    else return lenHead'
+
+deltaInsP :: Parser DeltaInstruction
+deltaInsP = do
+    byte1 <- peekWord8'
+    if msb byte1
+      then copyP
+      else insertP
+  where
+    -- | See the internals of Data.Attorparsec.Binary
+    packBytes :: BS.ByteString -> Word32
+    packBytes = BS.foldl' (\n h -> (n `shiftL` 8) .|. fromIntegral h) 0
+
+    -- | Copy instruction offset/length are stored as compressed little-endian
+    --   32 bit integers. The "cursor advance" mask, read from the copy
+    --   instruction itself, indicates whether to simply pad a byte with zeros
+    --   or to read an actual byte of data for the result.
+    --
+    --   E.g. if the last four bits of the copy instruction are `1010` and the
+    --   next two bytes are `11010111` `01001011`, the resulting 32 bit integer
+    --   is `11010111 00000000 01001011 00000000`
+    --
+    --   See https://codewords.recurse.com/issues/three/unpacking-git-packfiles
+    leCompressedP :: Word8 -> Int -> Parser Word32
+    leCompressedP curAdvMask maskLen =
+      fmap (packBytes . BS.pack . Prelude.reverse) $
+      sequence $ fmap (\b -> if b then anyWord8 else return 0) $
+      takeBits maskLen curAdvMask
+
+    takeBits :: Bits a => Int -> a -> [Bool]
+    takeBits n bs = List.take n $ fmap (bs `testBit`) [0..]
+    copyP = do
+      byte <- anyWord8
+      let ofsCursAdvances = byte .&. 0b00001111
+      let lenCursAdvances = byte .&. 0b01110000
+      ofs <- leCompressedP ofsCursAdvances 4
+      len <- leCompressedP lenCursAdvances 3
+      return $ Copy ofs len
+    insertP = do
+      len <- lsbs <$> anyWord8
+      dat <- SBS.takeFromLazyByteString (fromIntegral len) <$>
+        takeLazyByteString
+      return $ Insert dat
+
+deltaBodyP :: Parser DeltaBody
+deltaBodyP = do
+  sourceLen <- lengthP 0
+  targetLen <- lengthP 0
+  inss <- many1 deltaInsP
+  return $ DeltaBody sourceLen targetLen inss
+
+refDeltaP :: Parser RefDelta
+refDeltaP = do
+  sha1 <- take 20 >>= Sha1.fromByteString
+  db <- deltaBodyP
+  return $ RefDelta sha1 db
+
+ofsDeltaP :: Parser OfsDelta
+ofsDeltaP = do
+  negOfs <- lengthP 0
+  db <- deltaBodyP
+  return $ OfsDelta negOfs db
+
+getPackObjectData
+  :: MonadError GitError m
+  => PackHandle -> Word64
+  -> m (Either (ObjectType, SizedByteString) DeltaObject)
+getPackObjectData ph offset = do
+    (packObjTy, dataStart, inflatedSize) <- getPackObjectInfo ph offset
+    let objectData = SBS.takeFromLazyByteString (fromIntegral inflatedSize) $
+          decompress $
+          LBS.fromStrict $ mmapData (phMmap ph)
+            (FromStart $ fromIntegral dataStart)
+            (Length $ fromIntegral inflatedSize)
+    case packObjTy of
+      PoTyRefDelta -> Right . RefDelta' <$> doParse refDeltaP objectData
+      PoTyOfsDelta -> Right . OfsDelta' <$> doParse ofsDeltaP objectData
+      _ -> Left . (,objectData) <$> packObjTyToObjTy packObjTy
+  where
+    doParse p = either (throwError . ParseError) return . parseOnly p .
+      LBS.toStrict . SBS.toLazyByteString

--- a/src/Git/Pack/PackSet.hs
+++ b/src/Git/Pack/PackSet.hs
@@ -20,7 +20,8 @@ import Git.Types.SizedByteString (SizedByteString)
 
 import Git.Pack.Index
   (PackIndexState, openPackIndex, getPackRecordOffset)
-import Git.Pack.Delta (PackObjectChain(..), pocConsDelta, renderPackObjectChain)
+import Git.Pack.Delta
+  (PackObjectChain(..), pocAppendDelta, renderPackObjectChain)
 import Git.Pack.Pack
   ( PackHandle, openPackFile, getPackObjectData, RefDelta(..), OfsDelta(..)
   , DeltaObject(..))
@@ -60,10 +61,10 @@ getObjectChain sha1 = do
       PackObjectChain ty objData []
     handleEntity ph offset (Right delta) = case delta of
       RefDelta' rd ->
-        pocConsDelta (rdBody rd) <$>
+        pocAppendDelta (rdBody rd) <$>
         getObjectChain (rdBaseSha1 rd)
       OfsDelta' od ->
-        pocConsDelta (odBody od) <$>
+        pocAppendDelta (odBody od) <$>
         getObjectChainFromOffset ph (offset - odBaseNegOfs od)
 
     getObjectChainFromOffset ph offset =

--- a/src/Git/Pack/PackSet.hs
+++ b/src/Git/Pack/PackSet.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Git.Pack.PackSet where
+
+import Control.Exception (throwIO)
+import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Except (ExceptT(..), runExceptT, withExceptT, throwError)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.State (StateT(..), evalStateT)
+import Control.Monad.State.Class (MonadState(get, put))
+import Control.Monad.Trans (MonadTrans(..))
+import Data.List (isSuffixOf)
+import Data.Word
+import System.Directory (listDirectory)
+import System.FilePath.Posix ((</>))
+
+import Git.Types (Sha1, GitError, ObjectType)
+import Git.Types.Internal (replaceSuffix, liftEitherGitError)
+import Git.Types.SizedByteString (SizedByteString)
+
+import Git.Pack.Index
+  (PackIndexState, openPackIndex, getPackRecordOffset)
+import Git.Pack.Delta (PackObjectChain(..), pocConsDelta, renderPackObjectChain)
+import Git.Pack.Pack
+  ( PackHandle, openPackFile, getPackObjectData, RefDelta(..), OfsDelta(..)
+  , DeltaObject(..))
+
+type PackPair = (PackIndexState, PackHandle)
+type PackSet = [PackPair]
+type PackSetM m r = ExceptT GitError (StateT PackSet m) r
+
+openPackSet :: (MonadIO m, MonadError GitError m) => FilePath -> m PackSet
+openPackSet packDirPath = do
+  files <- liftIO $ listDirectory packDirPath
+  let indexNames = filter (".idx" `isSuffixOf`) files
+  packNames <- liftEitherGitError $ mapM (replaceSuffix "idx" "pack") indexNames
+  indexStates <- mapM (openPackIndex . (packDirPath </>)) indexNames
+  packHandles <- mapM (openPackFile . (packDirPath </>)) packNames
+  return $ zip indexStates packHandles
+
+-- This is a bit of a hack just to make it easier to use this code from Store...
+withPackSet :: MonadIO m => FilePath -> PackSetM m r -> m r
+withPackSet path m = do
+    ps <- except $ runExceptT $ openPackSet path
+    except $ evalStateT (runExceptT m) ps
+  where
+    except f = f >>= either (liftIO . throwIO) return
+
+packSetGetObjectData
+  :: Monad m
+  => Sha1 -> ExceptT GitError (StateT PackSet m) (ObjectType, SizedByteString)
+packSetGetObjectData sha1 = getObjectChain sha1 >>= renderPackObjectChain
+
+getObjectChain
+  :: Monad m => Sha1 -> ExceptT GitError (StateT PackSet m) PackObjectChain
+getObjectChain sha1 = do
+    packSetGetOffset sha1 >>= uncurry getObjectChainFromOffset
+  where
+    handleEntity _ _ (Left (ty, objData)) = return $
+      PackObjectChain ty objData []
+    handleEntity ph offset (Right delta) = case delta of
+      RefDelta' rd ->
+        pocConsDelta (rdBody rd) <$>
+        getObjectChain (rdBaseSha1 rd)
+      OfsDelta' od ->
+        pocConsDelta (odBody od) <$>
+        getObjectChainFromOffset ph (offset - odBaseNegOfs od)
+
+    getObjectChainFromOffset ph offset =
+      getPackObjectData ph offset >>= handleEntity ph offset
+
+packSetGetOffset
+  :: Monad m
+  => Sha1
+  -> ExceptT GitError (StateT PackSet m) (PackHandle, Word64)
+packSetGetOffset sha1 = withExceptT last $ statefulFirstSuccess go
+  where
+    go = do
+      offset <- liftToPackPair $ getPackRecordOffset sha1
+      (_, ph) <- get
+      return (ph, offset)
+
+liftToPackPair
+  :: Monad m
+  => ExceptT GitError (StateT PackIndexState m) a
+  -> ExceptT GitError (StateT PackPair m) a
+liftToPackPair m = ExceptT $ StateT $ \(pis, ph) ->
+  fmap (\(ea, pis') -> (ea, (pis', ph))) $ runStateT (runExceptT m) pis
+
+statefulFirstSuccess
+  :: Monad m => ExceptT e (StateT s m) a -> ExceptT [e] (StateT [s] m) a
+statefulFirstSuccess m = do
+    states <- lift get
+    (result, states') <- lift $ lift $
+      firstSuccess' (\s -> runStateT (runExceptT m) s) states
+    put states'
+    either throwError return result
+  where
+    firstSuccess'
+      :: Monad m => (s -> m (Either e a, s)) -> [s] -> m (Either [e] a, [s])
+    firstSuccess' = go [] []
+    go
+      :: Monad m => [e] -> [s] -> (s -> m (Either e a, s)) -> [s]
+      -> m (Either [e] a, [s])
+    go errs states' _ [] = return (Left $ reverse errs, reverse states')
+    go errs states' f (state:states) = do
+      (res, state') <- f state
+      case res of
+        Left e -> go (e : errs) (state' : states') f states
+        Right a -> return (Right a, (reverse $ state' : states') ++ states)

--- a/src/Git/Serialise.hs
+++ b/src/Git/Serialise.hs
@@ -24,6 +24,7 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time
   (minutesToTimeZone, timeZoneMinutes, ZonedTime(..), zonedTimeToUTC)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Data.Word
 import System.Posix (CMode(..))
 
 import Git.Types
@@ -45,14 +46,14 @@ class GitObject a where
   decodeObject :: MonadFail m => LBS.ByteString -> m a
   decodeObject = lazyParseOnly ((parseHeader >>= objectParser) <* endOfInput)
     where
-      parseHeader :: Parser Integer
+      parseHeader :: Parser Word64
       parseHeader = do
         _ <- (string $ objectName $ Proxy @a) <?> "object name"
         char_ ' ' >> decimal <* char_ '\NUL' <?> "object size"
 
   objectName :: proxy a -> BS.ByteString
   objectBody :: a -> SizedByteString
-  objectParser :: Integer -> Parser a
+  objectParser :: Word64 -> Parser a
 
 instance GitObject Blob where
   objectName _ = "blob"

--- a/src/Git/Store.hs
+++ b/src/Git/Store.hs
@@ -4,67 +4,47 @@ module Git.Store where
 
 import Codec.Compression.Zlib (compress, decompress)
 import Control.Exception (try, throwIO)
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Except (runExceptT, withExceptT)
-import Control.Monad.IO.Class (MonadIO(..))
-import Data.Attoparsec.ByteString (endOfInput)
+import Control.Monad (unless)
 import qualified Data.ByteString.Lazy as LBS
-import Data.List (isSuffixOf)
+import Data.Proxy
 import Data.Tagged (Tagged(..))
-import Data.Word
-import System.Directory (renameFile, createDirectoryIfMissing, listDirectory)
+import System.Directory (createDirectoryIfMissing)
 import System.FilePath.Posix ((</>))
-import System.IO (openTempFile, openBinaryFile, hClose, IOMode(..))
+import System.IO (openBinaryFile, IOMode(..))
 import System.IO.Error (isDoesNotExistError)
 
-import Git.Serialise (GitObject(..), lazyParseOnly)
-import Git.Types.Internal (firstSuccess, replaceSuffix)
-import Git.Types.Sha1 (Sha1, hashLazy, toHexString)
+import Git.Serialise
+  ( GitObject(..), decodeObject, encodeLooseObject, decodeLooseObject)
+import Git.Types (Sha1, toHexString)
 import qualified Git.Types.SizedByteString as SBS
-import Git.Pack
-  ( withPackIndex, getPackRecordOffset, openPackFile, getPackObjectInfo
-  , getPackObjectData)
+import Git.Pack (withPackSet, packSetGetObjectData)
+
 
 storeObject :: GitObject a => FilePath -> a -> IO (Tagged a Sha1)
-storeObject storePath obj = let encoded = encodeObject obj in do
-  (tmpPath, handle) <- openTempFile storePath "compressed_encoded_object"
-  LBS.hPut handle $ compress $ SBS.toLazyByteString $ encoded
-  hClose handle
-  -- FIXME: It might be good to try to parallelise the hashing with the file
-  -- writing:
-  let sha1 = hashLazy $ SBS.toLazyByteString encoded
-  let (sha1Head, filename) = splitAt 2 $ toHexString $ sha1
-  let dirPath = storePath </> sha1Head
-  createDirectoryIfMissing True dirPath
-  renameFile tmpPath $ dirPath </> filename
-  return $ Tagged sha1
+storeObject storePath obj =
+  let
+    (sha1, encoded) = encodeLooseObject obj
+    (sha1Head, filename) = splitAt 2 $ toHexString $ unTagged sha1
+    dirPath = storePath </> sha1Head
+  in do
+    createDirectoryIfMissing True dirPath
+    handle <- openBinaryFile (dirPath </> filename) WriteMode
+    LBS.hPut handle $ compress $ SBS.toLazyByteString $ encoded
+    return sha1
 
 retrieveObject :: forall a. GitObject a => FilePath -> Tagged a Sha1 -> IO a
 retrieveObject storePath sha1 = do
-  eOrObj <- try readDirectly
+  eOrObj <- try $ readDirectly >>= unwrap
   case eOrObj of
     Right obj -> return obj
     Left e -> if isDoesNotExistError e then readFromPack else throwIO e
   where
     (sha1Head, filename) = splitAt 2 $ toHexString $ unTagged sha1
     readDirectly = openBinaryFile (storePath </> sha1Head </> filename) ReadMode
-        >>= LBS.hGetContents >>= decodeObject . decompress
+        >>= LBS.hGetContents >>= decodeLooseObject . decompress
     readFromPack :: IO a
-    readFromPack = fmap (either error id) $ runExceptT $ do
-        files <- liftIO $ listDirectory $ storePath </> "pack"
-        let indexNames = filter (".idx" `isSuffixOf`) files
-        (indexName, packOffset) <- withExceptT (snd . head) $ firstSuccess
-          (searchPackIndex . (storePath </>) . ("pack" </>)) indexNames
-        packName <- replaceSuffix "idx" "pack" indexName
-        -- FIXME: this currently leaks too many details of how to look at pack
-        -- files...
-        ph <- openPackFile (storePath </> "pack" </> packName)
-        (ty, offset, size) <- getPackObjectInfo ph packOffset
-        -- FIXME: this DOES NOT CHECK THE OBJECT TYPE!
-        lazyParseOnly (objectParser (fromIntegral size) <* endOfInput)
-          . SBS.toLazyByteString
-          $ getPackObjectData ph offset size
-    searchPackIndex :: (MonadIO m, MonadError String m) => FilePath -> m Word64
-    searchPackIndex path =
-      withPackIndex path (getPackRecordOffset $ unTagged sha1) >>=
-      either (throwError . show) return
+    readFromPack = do
+      (objTy, sbs) <- withPackSet (storePath </> "pack") $
+        packSetGetObjectData $ unTagged sha1
+      unless (objTy == objectType (Proxy @a)) $ error "Bad object type"
+      decodeObject sbs

--- a/src/Git/Types.hs
+++ b/src/Git/Types.hs
@@ -1,4 +1,5 @@
 module Git.Types (module X) where
 
+import Git.Types.Error as X
 import Git.Types.Sha1 as X
 import Git.Types.Objects as X

--- a/src/Git/Types/Error.hs
+++ b/src/Git/Types/Error.hs
@@ -1,0 +1,31 @@
+module Git.Types.Error where
+
+import Data.Word
+
+data GitError
+  = ErrorWithIO IOError
+  | GenericError String
+  | ParseError String
+  | UnsupportedPackIndexVersion
+  | UnsupportedOperation String
+  | Sha1NotInIndex
+  | UnsupportedPackFileVersion
+  | UnrecognisedPackObjectType Word8
+  | FailedPreDeltaApplicationLengthCheck
+  | FailedPostDeltaApplicationLengthCheck
+  deriving Eq
+
+instance Show GitError where
+  show e = case e of
+    ErrorWithIO ioe -> "IO error: " ++ show ioe
+    GenericError s -> "Error: " ++ s
+    ParseError s -> "Parse error: " ++ s
+    UnsupportedPackIndexVersion -> "Unsupported pack index version"
+    UnsupportedOperation s -> "Unsupported operation: " ++ s
+    Sha1NotInIndex -> "sha1 not in index"
+    UnsupportedPackFileVersion -> "Unsupported pack file version"
+    UnrecognisedPackObjectType w -> "Unrecognised pack object type: " ++ show w
+    FailedPreDeltaApplicationLengthCheck ->
+      "Failed pre-delta-application length check"
+    FailedPostDeltaApplicationLengthCheck ->
+      "Failed post-delta-application length check"

--- a/src/Git/Types/Error.hs
+++ b/src/Git/Types/Error.hs
@@ -1,5 +1,6 @@
 module Git.Types.Error where
 
+import Control.Exception (Exception)
 import Data.Word
 import Text.Printf (printf)
 
@@ -32,3 +33,5 @@ instance Show GitError where
     FailedPostDeltaApplicationLengthCheck actual expected -> printf
       "Failed post-delta-application length check: %d (actual) /= %d (expected)"
       actual expected
+
+instance Exception GitError

--- a/src/Git/Types/Error.hs
+++ b/src/Git/Types/Error.hs
@@ -1,6 +1,7 @@
 module Git.Types.Error where
 
 import Data.Word
+import Text.Printf (printf)
 
 data GitError
   = ErrorWithIO IOError
@@ -11,8 +12,8 @@ data GitError
   | Sha1NotInIndex
   | UnsupportedPackFileVersion
   | UnrecognisedPackObjectType Word8
-  | FailedPreDeltaApplicationLengthCheck
-  | FailedPostDeltaApplicationLengthCheck
+  | FailedPreDeltaApplicationLengthCheck Word64 Word64
+  | FailedPostDeltaApplicationLengthCheck Word64 Word64
   deriving Eq
 
 instance Show GitError where
@@ -25,7 +26,9 @@ instance Show GitError where
     Sha1NotInIndex -> "sha1 not in index"
     UnsupportedPackFileVersion -> "Unsupported pack file version"
     UnrecognisedPackObjectType w -> "Unrecognised pack object type: " ++ show w
-    FailedPreDeltaApplicationLengthCheck ->
-      "Failed pre-delta-application length check"
-    FailedPostDeltaApplicationLengthCheck ->
-      "Failed post-delta-application length check"
+    FailedPreDeltaApplicationLengthCheck actual expected -> printf
+      "Failed pre-delta-application length check: %d (actual) /= %d (expected)"
+      actual expected
+    FailedPostDeltaApplicationLengthCheck actual expected -> printf
+      "Failed post-delta-application length check: %d (actual) /= %d (expected)"
+      actual expected

--- a/src/Git/Types/Error.hs
+++ b/src/Git/Types/Error.hs
@@ -13,6 +13,7 @@ data GitError
   | Sha1NotInIndex
   | UnsupportedPackFileVersion
   | UnrecognisedPackObjectType Word8
+  | FailedDeltaConsistencyCheck
   | FailedPreDeltaApplicationLengthCheck Word64 Word64
   | FailedPostDeltaApplicationLengthCheck Word64 Word64
   deriving Eq
@@ -27,6 +28,7 @@ instance Show GitError where
     Sha1NotInIndex -> "sha1 not in index"
     UnsupportedPackFileVersion -> "Unsupported pack file version"
     UnrecognisedPackObjectType w -> "Unrecognised pack object type: " ++ show w
+    FailedDeltaConsistencyCheck -> "Failed delta consistency check"
     FailedPreDeltaApplicationLengthCheck actual expected -> printf
       "Failed pre-delta-application length check: %d (actual) /= %d (expected)"
       actual expected

--- a/src/Git/Types/Internal.hs
+++ b/src/Git/Types/Internal.hs
@@ -17,6 +17,7 @@ import qualified Data.ByteString.Internal as BSIntern
 import Data.Word
 import Foreign.ForeignPtr (ForeignPtr)
 
+import Git.Types.Error (GitError(..))
 import Git.Types.Sha1 (Sha1)
 import qualified Git.Types.Sha1 as Sha1
 
@@ -26,6 +27,9 @@ instance MonadFail (Either String) where
 -- FIXME: replace with Control.Monad.Except.liftEither when >= 2.2.2
 liftEither :: MonadError e m => Either e a -> m a
 liftEither = either throwError return
+
+liftEitherGitError :: MonadError GitError m => Either String a -> m a
+liftEitherGitError = liftEither . first GenericError
 
 firstSuccess
   :: Monad m => (a -> ExceptT e m b) -> [a] -> ExceptT [(a, e)] m (a, b)

--- a/src/Git/Types/Objects.hs
+++ b/src/Git/Types/Objects.hs
@@ -56,3 +56,10 @@ data Object
   | ObjTree Tree
   | ObjCommit Commit
   | ObjTag Tag
+
+objectType :: Object -> ObjectType
+objectType obj = case obj of
+  ObjBlob _ -> ObjTyBlob
+  ObjTree _ -> ObjTyTree
+  ObjCommit _ -> ObjTyCommit
+  ObjTag _ -> ObjTyTag

--- a/src/Git/Types/Sha1.hs
+++ b/src/Git/Types/Sha1.hs
@@ -1,7 +1,7 @@
 module Git.Types.Sha1
   ( Sha1, unSha1, sha1Size, fromByteString
   , toHexString, fromHexString
-  , hashLazy
+  , hashLazy, hashSbs
   ) where
 
 import Prelude hiding (fail)
@@ -12,6 +12,9 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as LBS
+
+import Git.Types.SizedByteString (SizedByteString)
+import qualified Git.Types.SizedByteString as SBS
 
 newtype Sha1 = Sha1 {unSha1 :: BS.ByteString} deriving (Eq, Ord)
 
@@ -35,3 +38,6 @@ fromHexString s = case Base16.decode $ Char8.pack s of
 
 hashLazy :: LBS.ByteString -> Sha1
 hashLazy = Sha1 . SHA1.hashlazy
+
+hashSbs :: SizedByteString -> Sha1
+hashSbs = hashLazy . SBS.toLazyByteString

--- a/src/Git/Types/SizedByteString.hs
+++ b/src/Git/Types/SizedByteString.hs
@@ -1,9 +1,10 @@
 module Git.Types.SizedByteString
   ( SizedByteString, fromStrictByteString, fromHandle, length
-  , toLazyByteString, takeFromLazyByteString)
+  , toLazyByteString, takeFromLazyByteString, take, drop)
 where
 
-import Prelude hiding (length)
+import Prelude hiding (length, take, drop)
+import Data.Int
 import Data.Monoid ((<>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -14,7 +15,8 @@ import System.IO (Handle, hSeek, SeekMode(..), hTell)
 data SizedByteString
   = SizedByteString
   { sbsLength :: Word64
-  , sbsBytes :: LBS.ByteString}
+  , sbsBytes :: LBS.ByteString
+  } deriving (Show, Eq)
 
 instance IsString SizedByteString where
   fromString = fromStrictByteString . fromString
@@ -51,3 +53,11 @@ getRemainingFileSize h = do
   sizeBytes <- hSeek h SeekFromEnd 0 >> hTell h
   hSeek h AbsoluteSeek initialPos
   return sizeBytes
+
+take :: Int64 -> SizedByteString -> SizedByteString
+take i (SizedByteString l lbs) =
+  SizedByteString (fromIntegral $ min i $ fromIntegral l) $ LBS.take i lbs
+
+drop :: Int64 -> SizedByteString -> SizedByteString
+drop i (SizedByteString l lbs) =
+  SizedByteString (fromIntegral $ max 0 $ fromIntegral l - i) $ LBS.drop i lbs

--- a/src/Git/Types/SizedByteString.hs
+++ b/src/Git/Types/SizedByteString.hs
@@ -11,12 +11,16 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.String (IsString(..))
 import Data.Word
 import System.IO (Handle, hSeek, SeekMode(..), hTell)
+import Text.Printf (printf)
 
 data SizedByteString
   = SizedByteString
   { sbsLength :: Word64
   , sbsBytes :: LBS.ByteString
-  } deriving (Show, Eq)
+  } deriving Eq
+
+instance Show SizedByteString where
+  show = printf "<SizedByteString: %d>" . sbsLength
 
 instance IsString SizedByteString where
   fromString = fromStrictByteString . fromString

--- a/src/Git/Types/SizedByteString.hs
+++ b/src/Git/Types/SizedByteString.hs
@@ -7,6 +7,7 @@ import Prelude hiding (length)
 import Data.Monoid ((<>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import Data.String (IsString(..))
 import Data.Word
 import System.IO (Handle, hSeek, SeekMode(..), hTell)
 
@@ -14,6 +15,9 @@ data SizedByteString
   = SizedByteString
   { sbsLength :: Word64
   , sbsBytes :: LBS.ByteString}
+
+instance IsString SizedByteString where
+  fromString = fromStrictByteString . fromString
 
 instance Monoid SizedByteString where
   mempty = SizedByteString 0 mempty

--- a/test/Git/Pack/DeltaSpec.hs
+++ b/test/Git/Pack/DeltaSpec.hs
@@ -1,0 +1,43 @@
+module Git.Pack.DeltaSpec where
+
+import Test.Hspec
+
+import Control.Monad.Except (runExceptT)
+import Control.Monad.Identity (runIdentity)
+
+import Git.Types (GitError(..), ObjectType(..))
+import Git.Pack.Delta
+  ( DeltaInstruction(..), DeltaBody(..), applyDelta
+  , PackObjectChain(..), renderPackObjectChain)
+
+spec :: Spec
+spec = do
+  describe "Pack.Delta" $ do
+    describe "applyDelta" $ do
+      it "should execute a series of instructions correctly" $
+        let
+          base = "hello world cruft bye!"
+          db = DeltaBody 22 66
+            [ Copy 0 6, Insert "is a greeting. The ", Copy 6 6
+            , Insert "is where we live. ", Copy 0 11, Insert ", ", Copy 18 4]
+        in
+          runIdentity (runExceptT $ applyDelta base db) `shouldBe` Right
+          "hello is a greeting. The world is where we live. hello world, bye!"
+
+      it "should refuse to act on base data of incorrect length" $
+        runIdentity (runExceptT $ applyDelta "hello" $ DeltaBody 3 0 [])
+        `shouldBe` Left (FailedPreDeltaApplicationLengthCheck 5 3)
+
+      it "should notice an resulting string of incorrect length" $
+        runIdentity (runExceptT $ applyDelta "hello" $ DeltaBody 5 1 [])
+        `shouldBe` Left (FailedPostDeltaApplicationLengthCheck 0 1)
+
+    describe "renderPackObjectData" $ do
+      it "should process in the correct order" $
+        let
+          poc = PackObjectChain ObjTyBlob "hello world"
+            [ DeltaBody 11 15 [Insert "greetings", Copy 5 6]
+            , DeltaBody 15 16 [Copy 0 10, Insert "planet"]]
+        in
+          runIdentity (runExceptT $ renderPackObjectChain poc)
+          `shouldBe` Right (ObjTyBlob, "greetings planet")

--- a/test/Git/Pack/PackSpec.hs
+++ b/test/Git/Pack/PackSpec.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE BinaryLiterals #-}
+
+module Git.Pack.PackSpec where
+
+import Test.Hspec
+import Test.QuickCheck (forAll, choose)
+
+import Data.Attoparsec.ByteString (parseOnly)
+import qualified Data.ByteString as BS
+import Data.Word
+
+import Git.Pack.Pack (chunkNumLeP', objHeadP)
+
+spec :: Spec
+spec = describe "Pack.Pack" $ do
+  describe "Length parser" $ do
+    it "should parse a single byte" $ forAll (choose (minBound, 127)) $
+      \(w :: Word8) ->
+        either error (== fromIntegral w) $
+        parseOnly (chunkNumLeP' 0 0) $ BS.singleton w
+    it "should parse multiple bytes until MSB unset" $
+      let
+        --                 4 --+     12 --+  24 -+            25 --+
+        --                     v          v      v                 v
+        bs = BS.pack [0b10000001, 0b10000010, 0b11000000, 0b00000001]
+        parsed = either error id $ parseOnly (chunkNumLeP' 4 0b00000100) bs
+        --                                                          ^
+        --                                                      2 --+
+      in
+        parsed `shouldBe` sum (fmap (2^) [25, 24, 12, 4, 2 :: Int])

--- a/test/Git/Pack/PackSpec.hs
+++ b/test/Git/Pack/PackSpec.hs
@@ -6,25 +6,42 @@ import Test.Hspec
 import Test.QuickCheck (forAll, choose)
 
 import Data.Attoparsec.ByteString (parseOnly)
+import Data.Bits (shiftL)
 import qualified Data.ByteString as BS
 import Data.Word
 
-import Git.Pack.Pack (chunkNumLeP', objHeadP)
+import Git.Pack.Pack (chunkNumLeP', chunkNumBeP)
 
 spec :: Spec
 spec = describe "Pack.Pack" $ do
-  describe "Length parser" $ do
-    it "should parse a single byte" $ forAll (choose (minBound, 127)) $
-      \(w :: Word8) ->
+  describe "Little-endian chunked number parser" $ do
+    it "should parse a single byte" $ forAll (choose (0 :: Word8, 127)) $
+      \w ->
         either error (== fromIntegral w) $
         parseOnly (chunkNumLeP' 0 0) $ BS.singleton w
     it "should parse multiple bytes until MSB unset" $
       let
-        --                 4 --+     12 --+  24 -+            25 --+
-        --                     v          v      v                 v
-        bs = BS.pack [0b10000001, 0b10000010, 0b11000000, 0b00000001]
+        --                     4         12      24 21             25 +- Ignore
+        --                     v          v      v  v              v  v
+        bs = BS.pack [0b10000001, 0b10000010, 0b11001000, 0b00000001, 255]
         parsed = either error id $ parseOnly (chunkNumLeP' 4 0b00000100) bs
         --                                                          ^
         --                                                      2 --+
       in
-        parsed `shouldBe` sum (fmap (2^) [25, 24, 12, 4, 2 :: Int])
+        parsed `shouldBe` sum (fmap (2^) [25, 24, 21, 12, 4, 2 :: Int])
+
+  describe "Big-endian chunked number parser (with addition)" $ do
+    it "should parse a single byte as-is" $ forAll (choose (0 :: Word8, 127)) $
+      \w ->
+        either error (== fromIntegral w) $
+        parseOnly (chunkNumBeP) $ BS.singleton w
+    it "should parse multiple bytes until MSB unset" $
+      let
+        --               14    8     7     0    Ignore
+        --               v     v     v     v    |------->
+        bs = BS.pack [0b10010010, 0b01110101, 0b011111000]
+        parsed = either error id $ parseOnly chunkNumBeP bs
+      in
+        --    This +1 is slightly strange ---+
+        --                                   v
+        parsed `shouldBe` (shiftL (0b10010 + 1) 7) + 0b1110101

--- a/test/Git/Types/SizedByteStringSpec.hs
+++ b/test/Git/Types/SizedByteStringSpec.hs
@@ -9,7 +9,7 @@ import qualified Git.Types.SizedByteString as SBS
 
 spec :: Spec
 spec = do
-  describe "SizedByteString" $
+  describe "SizedByteString" $ do
     describeWithVirtFile "fromFilePath" $ do
       it "should report the correct ByteString length" $ \h -> do
         sbs <- SBS.fromHandle h
@@ -18,6 +18,22 @@ spec = do
       it "should provide the correct content" $ \h -> do
         sbs <- SBS.fromHandle h
         SBS.toLazyByteString sbs `shouldBe` "hello world"
+
+    describe "take" $ let sbs = SBS.fromStrictByteString "hello" in do
+      it "should report the correct length when i < len" $
+        SBS.take 3 sbs `shouldBe` SBS.fromStrictByteString "hel"
+      it "should report the correct length when i = len" $
+        SBS.take (fromIntegral $ SBS.length sbs) sbs `shouldBe` sbs
+      it "should report the correct length when i > len" $
+        SBS.take (fromIntegral $ SBS.length sbs + 1) sbs `shouldBe` sbs
+
+    describe "drop" $ let sbs = SBS.fromStrictByteString "world" in do
+      it "should report the correct length when i < len" $
+        SBS.drop 3 sbs `shouldBe` SBS.fromStrictByteString "ld"
+      it "should report the correct length when i = len" $
+        SBS.drop (fromIntegral $ SBS.length sbs) sbs `shouldBe` mempty
+      it "should report the correct length when i > len" $
+        SBS.drop (fromIntegral $ SBS.length sbs + 1) sbs `shouldBe` mempty
 
 describeWithVirtFile :: String -> SpecWith Handle -> Spec
 describeWithVirtFile description = around (\spec' -> do


### PR DESCRIPTION
This means we can get anything we like from a packfile now, I believe.

It also may be a little too general. There's a comment in the `git` [source code](https://github.com/git/git/blob/master/packfile.c#L1054) that seems to imply that deltas can only ever be to other objects within the same packfile. (And also, I think, only up to a certain distance away, because I think it memory maps the pack file in a window when it's verifying it)