### PR TITLE
Switch all path handling to use System.Path

### DIFF
--- a/hs-git-tools.cabal
+++ b/hs-git-tools.cabal
@@ -39,8 +39,6 @@ library
     , bytestring
     , containers
     , cryptohash
-    , directory
-    , filepath
     , mmap
     , mtl
     , pathtype

--- a/src/Git/Index/Parser.hs
+++ b/src/Git/Index/Parser.hs
@@ -24,8 +24,8 @@ import Data.Text.Encoding (decodeUtf8)
 import Data.Time.Clock.POSIX (POSIXTime, systemToPOSIXTime)
 import Data.Time.Clock.System (SystemTime(..))
 import Data.Word
-import System.IO (openBinaryFile, IOMode(..))
 import qualified System.Path as Path
+import System.Path.IO (openBinaryFile, IOMode(..))
 import System.Posix.Types (CDev(..), CIno(..), CUid(..), CGid(..))
 
 import Git.Pack (chunkNumBeP)
@@ -45,7 +45,7 @@ openIndex' path = p path >>= openIndex
 
 openIndex :: (MonadIO m, MonadError GitError m) => Path.AbsFile -> m Index
 openIndex path = do
-  content <- liftIO $ openBinaryFile (Path.toString path) ReadMode >>=
+  content <- liftIO $ openBinaryFile path ReadMode >>=
     LBS.hGetContents
   either (throwError . ParseError) return $
     lazyParseOnly indexP content

--- a/src/Git/Internal.hs
+++ b/src/Git/Internal.hs
@@ -53,12 +53,6 @@ firstSuccess f as = ExceptT $ go (fmap (\a -> (a, f a)) as) []
     go ((a, exT):aexTs) aes = runExceptT exT >>=
       either (go aexTs . (: aes) . (a,)) (return . Right . (a,))
 
-replaceSuffix :: (Eq a, MonadFail m) => [a] -> [a] -> [a] -> m [a]
-replaceSuffix old new s = do
-  delta <- dropLengthMaybe old s
-  let (prefix, old') = splitLength delta s
-  if old' == old then return $ prefix ++ new else fail "suffix did not match"
-
 splitLength :: [a] -> [b] -> ([b], [b])
 splitLength as bs = first reverse $ go [] as bs
   where

--- a/src/Git/Pack/Pack.hs
+++ b/src/Git/Pack/Pack.hs
@@ -21,6 +21,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as List
 import Data.Word
 import System.IO.MMap (mmapFileForeignPtr, Mode(..))
+import qualified System.Path as Path
 import Text.Printf (printf)
 
 import Git.Internal
@@ -60,9 +61,10 @@ data PackHandle = PackHandle
   , phNumObjects :: Word32
   } deriving (Show)
 
-openPackFile :: (MonadIO m, MonadError GitError m) => FilePath -> m PackHandle
+openPackFile
+  :: (MonadIO m, MonadError GitError m) => Path.AbsFile -> m PackHandle
 openPackFile path = do
-    h <- liftIO $ mmapFileForeignPtr path ReadOnly Nothing
+    h <- liftIO $ mmapFileForeignPtr (Path.toString path) ReadOnly Nothing
     (version, numObjects) <- either (throwError . ParseError) return $
         parseOnly headerP $ mmapData h (FromStart 0) (Length 12)
     unless (version == 2) $ throwError UnsupportedPackFileVersion

--- a/src/Git/Pack/PackSet.hs
+++ b/src/Git/Pack/PackSet.hs
@@ -10,12 +10,11 @@ import Control.Monad.State (StateT(..), evalStateT)
 import Control.Monad.State.Class (MonadState(get, put))
 import Control.Monad.Trans (MonadTrans(..))
 import qualified Data.ByteString as BS
-import Data.List (isSuffixOf)
 import Data.Word
-import System.Directory (listDirectory)
-import System.FilePath.Posix ((</>))
+import qualified System.Path as Path
+import System.Path ((</>))
+import System.Path.Directory (filesInDir)
 
-import Git.Internal (replaceSuffix, liftEitherGitError)
 import Git.Objects (ObjectType)
 import Git.Sha1 (Sha1)
 import Git.Types (GitError)
@@ -32,17 +31,17 @@ type PackPair = (PackIndexState, PackHandle)
 type PackSet = [PackPair]
 type PackSetM m r = ExceptT GitError (StateT PackSet m) r
 
-openPackSet :: (MonadIO m, MonadError GitError m) => FilePath -> m PackSet
-openPackSet packDirPath = do
-  files <- liftIO $ listDirectory packDirPath
-  let indexNames = filter (".idx" `isSuffixOf`) files
-  packNames <- liftEitherGitError $ mapM (replaceSuffix "idx" "pack") indexNames
-  indexStates <- mapM (openPackIndex . (packDirPath </>)) indexNames
-  packHandles <- mapM (openPackFile . (packDirPath </>)) packNames
+openPackSet :: (MonadIO m, MonadError GitError m) => Path.AbsDir -> m PackSet
+openPackSet packDir = do
+  files <- liftIO $ filesInDir packDir
+  let indexNames = filter (Path.hasExtension ".idx") files
+  let packNames = flip Path.replaceExtension "pack" <$> indexNames
+  indexStates <- mapM (openPackIndex . (packDir </>)) indexNames
+  packHandles <- mapM (openPackFile . (packDir </>)) packNames
   return $ zip indexStates packHandles
 
 -- This is a bit of a hack just to make it easier to use this code from Store...
-withPackSet :: MonadIO m => FilePath -> PackSetM m r -> m r
+withPackSet :: MonadIO m => Path.AbsDir -> PackSetM m r -> m r
 withPackSet path m = do
     ps <- except $ runExceptT $ openPackSet path
     except $ evalStateT (runExceptT m) ps

--- a/src/Git/Refs.hs
+++ b/src/Git/Refs.hs
@@ -10,10 +10,11 @@ import qualified Data.ByteString as BS
 import Data.Tagged (Tagged(..))
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
-import System.FilePath.Posix ((</>))
-import System.Directory (listDirectory)
-import System.IO (withBinaryFile, IOMode(..))
 import System.IO.Error (isDoesNotExistError)
+import qualified System.Path as Path
+import System.Path ((</>))
+import System.Path.Directory (filesInDir)
+import System.Path.IO (withBinaryFile, IOMode(..))
 
 import Git.Internal ()
 import Git.Objects (Commit)
@@ -36,26 +37,31 @@ data RtRemote = RtRemote {rtRemoteName :: String} deriving (Show, Eq)
 data Ref rt = Ref {refType :: rt, unRef :: String} deriving (Show, Eq)
 
 class RefType rt where
-  refTypePath :: Repo -> rt -> FilePath
+  refTypePath :: Repo -> rt -> Path.AbsDir
   refTypePathParser :: Parser (Ref rt)
 
 instance RefType RtHead where
-  refTypePath repo _ = repoRefsPath repo </> "heads"
+  refTypePath repo _ = repoRefsPath repo </> Path.relDir "heads"
   refTypePathParser = string "refs/heads/" >> (Ref RtHead <$> stringParser)
+
 instance RefType RtTag where
-  refTypePath repo _ = repoRefsPath repo </> "tags"
+  refTypePath repo _ = repoRefsPath repo </> Path.relDir "tags"
   refTypePathParser = string "refs/tags/" >> (Ref RtTag <$> stringParser)
+
 instance RefType RtRemote where
-  refTypePath repo rt = repoRefsPath repo </> "remotes" </> rtRemoteName rt
+  refTypePath repo rt =
+    repoRefsPath repo </> Path.relDir "remotes"
+    </> Path.relDir (rtRemoteName rt)
   refTypePathParser = do
     _ <- string "refs/remotes/"
+    -- FIXME: test this parser - I think takeTill will leave the '/' on
     remoteName <- decodeString <$> Char8.takeTill (== '/')
     refName <- stringParser
     return $ Ref (RtRemote remoteName) refName
 
 getRefs :: RefType rt => Repo -> rt -> IO [Ref rt]
-getRefs repo rt = either filterError (fmap $ Ref rt) <$>
-    try (listDirectory $ refTypePath repo rt)
+getRefs repo rt = either filterError (fmap $ Ref rt . Path.toString) <$>
+    try (filesInDir $ refTypePath repo rt)
   where
     filterError e = if isDoesNotExistError e then [] else throw e
 
@@ -65,7 +71,8 @@ openRef
 openRef repo ref = Tagged <$> getSha1 repo ref
 
 instance RefType rt => Sha1Pointer (Ref rt) where
-  getSha1 repo ref = let path = refTypePath repo (refType ref) </> unRef ref in
+  getSha1 repo ref =
+    let path = refTypePath repo (refType ref) </> Path.relFile (unRef ref) in
     liftIO (
       withBinaryFile path ReadMode
       (fmap (Sha1.fromHexText . Text.stripEnd . decodeUtf8) . BS.hGetContents))


### PR DESCRIPTION
because the `pathtype` adds some nice safety :+1: 